### PR TITLE
NEW: Extension point for extra data to complete purchases

### DIFF
--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -109,6 +109,8 @@ class PurchaseService extends PaymentService{
 			'currency' => $this->payment->MoneyCurrency
 		));
 
+		$this->payment->extend('onBeforeCompletePurchase', $gatewaydata);
+
 		$request = $this->oGateway()->completePurchase($gatewaydata);
 		$this->createMessage('CompletePurchaseRequest', $request);
 		$response = null;


### PR DESCRIPTION
Some gateways require more data than just amount and currency (e.g. SagePay Server requires transactionId and transactionReference), but `PaymentGatewayController` doesn’t pass any gateway data at all. This extension hook allows `$gatewaydata` to be updated in an extension.