### PR TITLE
Remove `Created` field from payment-admin filter dialogue.

### DIFF
--- a/code/model/Payment.php
+++ b/code/model/Payment.php
@@ -67,6 +67,7 @@ final class Payment extends DataObject{
 		$fields = $context->getSearchFields();
 
 		$fields->removeByName('Gateway');
+		$fields->removeByName('Created');
 		$fields->insertAfter(DropdownField::create('Gateway', _t('Payment.GATEWAY', 'Gateway'),
 			GatewayInfo::get_supported_gateways()
 		)->setHasEmptyDefault(true), 'Money');


### PR DESCRIPTION
Currently, it causes ModelAdmin to throw an error. Additionally, filtering by one specific date is not very useful. Filtering by a date-range would be better.