### PR TITLE
Deprecate the old config API.

### DIFF
--- a/code/services/PaymentService.php
+++ b/code/services/PaymentService.php
@@ -16,15 +16,15 @@ use Omnipay\Common\GatewayFactory;
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\AbstractRequest;
 
-abstract class PaymentService extends Object{
-
+abstract class PaymentService extends Object
+{
 	/**
 	 * @var Guzzle\Http\ClientInterface
 	 */
 	private static $httpclient;
 
 	/**
-	 * @var Guzzle\Http\Message\Request
+	 * @var Symfony\Component\HttpFoundation\Request
 	 */
 	private static $httprequest;
 
@@ -142,15 +142,16 @@ abstract class PaymentService extends Object{
 	 * @return AbstractGateway omnipay gateway class
 	 */
 	public function oGateway() {
+        $gatewayName = $this->payment->Gateway;
 		$gateway = $this->getGatewayFactory()->create(
-			$this->payment->Gateway,
+            $gatewayName,
 			self::$httpclient,
 			self::$httprequest
 		);
 
-		$parameters = Config::inst()->get('Payment', 'parameters');
-		if (isset($parameters[$this->payment->Gateway])) {
-			$gateway->initialize($parameters[$this->payment->Gateway]);
+		$parameters = GatewayInfo::getParameters($gatewayName);
+		if (is_array($parameters)) {
+			$gateway->initialize($parameters);
 		}
 
 		return $gateway;

--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -49,7 +49,7 @@ class PurchaseService extends PaymentService
 
         // We only look for a card if we aren't already provided with a token
         // Increasingly we can expect tokens or nonce's to be more common (e.g. Stripe and Braintree)
-        $tokenKey = Payment::config()->token_key ?: 'token';
+        $tokenKey = GatewayInfo::getTokenKey($this->payment->Gateway);
         if (empty($gatewaydata[$tokenKey])) {
             $gatewaydata['card'] = $this->getCreditCard($data);
         } elseif ($tokenKey !== 'token') {

--- a/docs/en/PayPalExpressSetup.md
+++ b/docs/en/PayPalExpressSetup.md
@@ -25,15 +25,16 @@ Configure your yaml file:
 Name: payment
 ---
 Payment:
-    file_logging: 1
-    allowed_gateways:
-        - 'PayPal_Express'
+  file_logging: 1
+  allowed_gateways:
+    - 'PayPal_Express'
+GatewayInfo:
+  PayPal_Express:
     parameters:
-        PayPal_Express:
-            username: 'name-facilitator_api1.yourdomain.com'
-            password: '327593262995'
-            signature: 'ABACEFAFASVAEVAWEVAEVAWEAEDASDFSAFasdf.ASVawevawevasdva'
-            testMode: true
+      username: 'name-facilitator_api1.yourdomain.com'
+      password: '327593262995'
+      signature: 'ABACEFAFASVAEVAWEVAEVAWEAEDASDFSAFasdf.ASVawevawevasdva'
+      testMode: true
 ```
 
 Don't forgt to add `testMode: true` so that we use the PayPal sandbox.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -88,6 +88,72 @@ Your model you connect payments to will generally be something like: `Bill`, `In
 An extension (`Payable`) has been written to provide the above functionality.
 
 
+## Configuration
+
+You can configure the allowed Gateways for payments using YAML config files. Example:
+
+```
+Payment:
+  allowed_gateways:
+    - Manual
+    - PayPal_Express
+    - Stripe
+```
+
+To configure Gateway properties, please create an entry for each Gateway under `GatewayInfo`. Example:
+
+```
+GatewayInfo:
+  PayPal_Express:
+    properties:
+      username: 'my.api.username'
+      password: 'APIPASSWORD'
+      testMode: true
+      # More gateway properties
+  Stripe:
+    use_authorize: true
+    properties:
+      # Gateway Properties
+```
+
+Each Gateway can have the following settings:
+
+ - `is_manual` *boolean*: Set this to true if this gateway should be considered a "Manual" Payment (eg. Invoice)
+ - `use_authorize` *boolean*: Whether or not this Gateway should prefer authorize over purchase
+ - `use_async_notification` *boolean*: When set to true, this Gateway will receive asynchronous notifications from the Payment provider
+ - `token_key` *string*: Key for the token parameter
+ - `required_fields` *array*: An array of required form-fields
+ - `properties` *map*: All gateway properties that will be passed along to the Omnipay Gateway instance
+
+### Changing parameters for live environment
+
+You can define separate properties for different environments. Here's an example of that:
+
+```
+GatewayConfig:
+  PayPal_Express:
+    use_authorize: true
+    token_key: 'token'
+    parameters:
+      username: 'sandbox.user.com'
+      password: '1234567890'
+      signature: 'RandomLettersAndNumbers012345'
+      testMode: true
+
+---
+Only:
+  environment: 'live'
+---
+# Supply different credentials for "live" environment.
+GatewayConfig:
+  PayPal_Express:
+    parameters:
+      username: 'live.user.ccom'
+      password: '0987654321'
+      signature: 'live-signature'
+      testMode: false # Make sure to override this to false
+```
+
 ## Gateway Features
 
 Different gateways have different features. This means you may get a different level of functionality, depending on the gateway you choose.
@@ -160,7 +226,7 @@ Here is how different gateway scenarios can play out:
 
  * Purchase requested / or request failed
  * Purchase request successful / or gateway responds with failure
- 
+
   ...client now visits external gateway...
 
  * Complete purchase requested / or request failed (triggered by client return, or by a call from gateway server)

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -22,12 +22,13 @@ abstract class PaymentTest extends FunctionalTest{
 			'Manual',
 			'Dummy'
 		);
-		Payment::config()->parameters = array(
-			'PaymentExpress_PxPay' => array(
-				'username' => 'EXAMPLEUSER',
-				'password' => '235llgwxle4tol23l'
-			)
-		);
+
+        Config::inst()->update('GatewayInfo', 'PaymentExpress_PxPay', array(
+           'parameters' => array(
+                'username' => 'EXAMPLEUSER',
+                'password' => '235llgwxle4tol23l'
+           )
+        ));
 
 		//set up a payment here to make tests shorter
 		$this->payment = Payment::create()

--- a/tests/PurchaseServiceTest.php
+++ b/tests/PurchaseServiceTest.php
@@ -222,7 +222,9 @@ class PurchaseServiceTest extends PaymentTest {
 
 
 	public function testTokenGateway() {
-        Payment::config()->token_key = 'token';
+        Config::inst()->update('GatewayInfo', 'PaymentExpress_PxPost', array(
+            'token_key' => 'token'
+        ));
 		$stubGateway = $this->getMockBuilder('Omnipay\Common\AbstractGateway')
             ->setMethods(array('purchase', 'getName'))
             ->getMock();
@@ -251,7 +253,9 @@ class PurchaseServiceTest extends PaymentTest {
 	}
 
     public function testTokenGatewayWithAlternateKey() {
-        Payment::config()->token_key = 'my_token';
+        Config::inst()->update('GatewayInfo', 'PaymentExpress_PxPost', array(
+            'token_key' => 'my_token'
+        ));
         $stubGateway = $this->getMockBuilder('Omnipay\Common\AbstractGateway')
             ->setMethods(array('purchase', 'getName'))
             ->getMock();


### PR DESCRIPTION
This means Payment should only configure the `allowed_gateways`.
Gateway configuration should go into `GatewayInfo`.

Added deprecation warnings. Updated docs and tests.